### PR TITLE
feat: add TestimonyCard component

### DIFF
--- a/src/components/Cards/TestimonyCard.astro
+++ b/src/components/Cards/TestimonyCard.astro
@@ -1,0 +1,190 @@
+---
+interface Props {
+  /**
+   * URL of the company's logo image
+   */
+  companyLogoUrl: string;
+
+  /**
+   * Name of the company providing the testimony
+   */
+  companyName: string;
+
+  /**
+   * Full name of the person providing the testimony
+   */
+  personFullName: string;
+
+  /**
+   * Job title or profession of the person providing the testimony
+   */
+  personJobTitle: string;
+
+  /**
+   * Testimonial text provided by the person
+   */
+  testimonyText: string;
+
+  /**
+   * URL to the full testimonial
+   */
+  fullTestimonyUrl: string;
+}
+
+const {
+  companyLogoUrl,
+  companyName,
+  personFullName,
+  personJobTitle,
+  testimonyText,
+  fullTestimonyUrl,
+} = Astro.props;
+---
+
+<article class="card-testimony">
+  <div class="card-testimony__company">
+    <img src={companyLogoUrl} alt={companyName} class="card-testimony__company-logo" />
+    <h2 class="card-testimony__company-name">{companyName}</h2>
+  </div>
+  <div class="card-testimony__person">
+    <h3 class="card-testimony__person-name">{personFullName}</h3>
+    <p class="card-testimony__person-job">{personJobTitle}</p>
+  </div>
+  <div class="card-testimony__bio">
+    <p class="card-testimony__text">{testimonyText}</p>
+  </div>
+  <a class="card-testimony__Link" href={fullTestimonyUrl} target="_blank" rel="noopener noreferrer">
+    <span class="card-testimony__Link-text"> Leer completo </span>
+    <span class="card-testimony__Link-icon">
+      <svg
+        width="24"
+        height="25"
+        viewBox="0 0 24 25"
+        fill="none"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          fill-rule="evenodd"
+          clip-rule="evenodd"
+          d="M6.32951 18.3961C5.89017 17.9567 5.89017 17.2444 6.32951 16.8051L14.159 8.97559H8.625C8.00368 8.97559 7.5 8.47191 7.5 7.85059C7.5 7.22927 8.00368 6.72559 8.625 6.72559H16.875C17.4963 6.72559 18 7.22927 18 7.85059V16.1006C18 16.7219 17.4963 17.2256 16.875 17.2256C16.2537 17.2256 15.75 16.7219 15.75 16.1006V10.5666L7.9205 18.3961C7.48116 18.8354 6.76884 18.8354 6.32951 18.3961Z"
+          fill="white"></path>
+      </svg>
+    </span>
+  </a>
+</article>
+
+<style>
+  .card-testimony {
+    /* Estilos para el bloque principal */
+    border-radius: 24px;
+    border: 1px solid #282828;
+    background: #0d0d0e;
+
+    display: flex;
+    width: 325px;
+    height: 428px;
+    padding: 24px;
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 24px;
+  }
+
+  .card-testimony__company {
+    /* Estilos para el contenedor de la compañía */
+    display: flex;
+    align-items: center;
+    gap: 8px;
+  }
+
+  .card-testimony__company-logo {
+    /* Estilos para el logo de la compañía */
+    width: 36px;
+    height: 36px;
+    border-radius: 50%;
+  }
+
+  .card-testimony__company-name {
+    /* Estilos para el nombre de la compañía */
+    font-family: Inter;
+    font-size: 16px;
+    font-weight: 600;
+    line-height: 19.36px;
+    text-align: left;
+  }
+
+  .card-testimony__person {
+    /* Estilos para el contenedor de la persona */
+    display: flex;
+    flex-direction: column;
+    gap: 9px;
+  }
+
+  .card-testimony__person-name {
+    /* Estilos para el nombre de la persona */
+    font-family: Inter;
+    font-size: 16px;
+    font-weight: 700;
+    line-height: 19.36px;
+    text-align: left;
+  }
+
+  .card-testimony__person-job {
+    /* Estilos para la profesión de la persona */
+    font-family: Inter;
+    font-size: 16px;
+    font-weight: 400;
+    line-height: 19.36px;
+    text-align: left;
+  }
+
+  .card-testimony__bio {
+    /* Estilos para el contenedor del testimonio */
+    overflow: hidden;
+    width: 277px;
+    height: 176px;
+    mask: linear-gradient(180deg, #0a0a0a 0%, transparent 100%);
+  }
+
+  .card-testimony__text {
+    /* Estilos para el texto del testimonio */
+    font-family: Inter;
+    font-size: 14px;
+    font-weight: 400;
+    line-height: 16.94px;
+    text-align: left;
+    color: #73769e;
+  }
+
+  .card-testimony__Link {
+    /* Estilos para el enlace al testimonio completo */
+    width: 176px;
+    height: 49px;
+    padding: 12px 16px 12px 16px;
+    gap: 10px;
+    border-radius: 9999px;
+    border: 1px 0px 0px 0px;
+    border: 1px solid #ffffff;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    text-decoration: none;
+    color: #ffffff;
+  }
+
+  .card-testimony__Link-text {
+    /* Estilos para el texto del enlace */
+    font-family: Inter;
+    font-size: 16px;
+    font-weight: 500;
+    line-height: 24px;
+    text-align: left;
+    text-wrap: nowrap;
+  }
+  .card-testimony__Link-icon {
+    /* Estilos para el icono del enlace */
+    width: 24px;
+    height: 24px;
+    gap: 0px;
+    opacity: 0px;
+  }
+</style>

--- a/src/components/Cards/index.ts
+++ b/src/components/Cards/index.ts
@@ -1,3 +1,4 @@
 export * from './Cards.type';
 export * from './CardWrapper';
 export { default as SimpleCard } from './SimpleCard/SimpleCard.astro';
+export { default as TestimonyCard } from './TestimonyCard.astro';


### PR DESCRIPTION
Esta PR añade un nuevo componente TestimonyCard #28 que muestra un testimonio, incluyendo el logo y nombre de la empresa, el nombre y la profesión de la persona, y el texto del testimonio.

### Comentarios
El contenedor del testimonio (.card-testimony__bio) se ha configurado con un tamaño fijo y una máscara para crear un efecto de desvanecimiento:
 

```
  .card-testimony__bio {
    /* Estilos para el contenedor del testimonio */
    overflow: hidden;
    width: 277px;
    height: 176px;

    /*  máscara activada  /*
    mask: linear-gradient(180deg, #0a0a0a 0%, transparent 100%);
  }
```

![image](https://github.com/AnaRangel/anarangel.github.io/assets/101147375/e0b9ac06-869d-4b6e-bdaf-2c8e2d4994c3)

Se ha comentado una versión alternativa de los estilos del contenedor del testimonio en caso de que sea necesario desactivar la máscara:
```
  .card-testimony__bio {
    /* Estilos para el contenedor del testimonio */
    overflow: hidden;
    width: 277px;
    height: 176px;

    /*  máscara  desactivada  /*
    /* mask: linear-gradient(180deg, #0a0a0a 0%, transparent 100%); */
  }
```

![image](https://github.com/AnaRangel/anarangel.github.io/assets/101147375/a6ef445e-ff7e-4d40-bcd5-0a091e35d531)

