### PR TITLE
Agregar despliegue automatico a Github Pages

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,41 @@
+name: Deploy to GitHub Pages
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+    paths-ignore:
+      - 'docs/**'
+      - 'README.md'
+      - 'commitlint.config.mjs'
+      - '.eslintrc.cjs'
+      - 'lint-staged.config.mjs'
+
+# Allow this job to clone the repo and create a page deployment
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout your repository using git
+        uses: actions/checkout@v4
+      - name: Install, build, and upload your site
+        uses: withastro/action@v2
+        with:
+          package-manager: pnpm@latest
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/astro.config.ts
+++ b/astro.config.ts
@@ -2,8 +2,7 @@ import { defineConfig } from 'astro/config';
 
 // https://astro.build/config
 export default defineConfig({
-  // TODO: Change url to the website
-  site: 'https://www.example.com',
+  site: 'https://anarangel.github.io',
   vite: {
     build: {
       cssMinify: 'lightningcss',


### PR DESCRIPTION
Usando la guía oficial de [astro](https://docs.astro.build/en/guides/deploy/github/#configure-a-github-action) se armo el workflow necesario para realizar el despliegue

Cosas a tener en cuenta:
- Se realizara un despliegue cada vez que sea realice un push o se acepte una Pull Request a la rama `main`
- El workflow propuesto usa siempre la ultima version de pnpm, pero esto es configurable en el archivo `.github/workflows/deploy.yml`
- El workflow propuesto usa siempre la version 20 de nodejs, pero esto es configurable en el archivo `.github/workflows/deploy.yml`
- En caso de que se use un dominio personalizado también se debe modificar el archivo `astro.config.ts`

> [!IMPORTANT]
> Actualmente el workflow no despliega la pagina si se modifica alguno de estos archivos
> - 'docs/**'
> - 'README.md'
> - 'commitlint.config.mjs'
> - '.eslintrc.cjs'
> - 'lint-staged.config.mjs'

[Ejemplo de ejecucion (Web no disponible por temas de URL)](https://github.com/SergioRibera/anarangel/actions/runs/9277425567)

Debe asegurarse de tener habilitadas las Github Pages desde la configuracion del repositorio (Suele activarse automaticamente)
![2024-05-28-19:01:12_sss](https://github.com/AnaRangel/anarangel.github.io/assets/56278796/c1f85c8c-ad45-4bee-8cdf-088e8c74841d)

this close #41 