### PR TITLE
fix: add-size-icons-social-footer

### DIFF
--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -75,7 +75,8 @@ import Twitch from '../../public/svg/twitch.svg';
   .icon {
     block-size: 1.5rem;
     height: 48px;
-    width: 48px;
+    width: 100%;
+    max-width: 48px;
   }
 
   .contribution,

--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -74,6 +74,8 @@ import Twitch from '../../public/svg/twitch.svg';
 
   .icon {
     block-size: 1.5rem;
+    height: 48px;
+    width: 48px;
   }
 
   .contribution,


### PR DESCRIPTION
#50 
Se aumenta el tamaño de los iconos a 48px x 48px
![image](https://github.com/AnaRangel/anarangel.github.io/assets/111030077/be29eabd-c15f-4fbf-ab41-33f3b82898c0)

