### PR TITLE
feat(styles): add size icons social media footer

### DIFF
--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -74,6 +74,9 @@ import Twitch from '../../public/svg/twitch.svg';
 
   .icon {
     block-size: 1.5rem;
+    height: 48px;
+    width: 100%;
+    max-width: 48px;
   }
 
   .contribution,


### PR DESCRIPTION
#50 

Se aumenta el tamaño de los iconos a 48px x 48px

![image](https://github.com/AnaRangel/anarangel.github.io/assets/111030077/49431400-02ea-4d55-b442-2d603bef2bba)
