### PR TITLE
fix(styles): modify accesibility item hover active navbar

### DIFF
--- a/src/components/Navbar.astro
+++ b/src/components/Navbar.astro
@@ -244,20 +244,18 @@
       list-style: none;
     }
 
-    .list-item:hover,
-    .list-item:active {
+    .list-item:has(a:hover),
+    .list-item:has(a:active) {
       background: radial-gradient(
         50% 50% at 50% 50%,
         rgba(255, 255, 255, 0.24) 0%,
         rgba(153, 153, 153, 0) 100%
       );
-
       color: white;
     }
 
     .list-item {
       padding-inline: 0.5rem;
-
       font-size: 1.2rem;
       text-decoration: none;
       font-size: 1rem;


### PR DESCRIPTION
Se modifican los estilos del menu Navbar porque el color de fondo de los items cambiaba sin activarse el cursor pointer:

Antes:


https://github.com/AnaRangel/anarangel.github.io/assets/111030077/df1b557a-0fb3-4918-8a79-2d7b1916184e

Ahora:


https://github.com/AnaRangel/anarangel.github.io/assets/111030077/a8e2e20a-b373-47d5-890c-27311675b2d3

