### PR TITLE
fix(components): :bug: remove scroll when navbar burger active

### DIFF
--- a/src/components/Navbar.astro
+++ b/src/components/Navbar.astro
@@ -292,9 +292,11 @@
     const isOpen = navBar.getAttribute(dataStatus) === 'open';
 
     if (isOpen) {
+      document.querySelector('body').style.removeProperty('overflow-y');
       navBar.setAttribute(dataStatus, 'close');
       burgerMenu.setAttribute(dataStatus, 'close');
     } else {
+      document.querySelector('body').style.overflowY = 'hidden';
       navBar.setAttribute(dataStatus, 'open');
       burgerMenu.setAttribute(dataStatus, 'open');
     }


### PR DESCRIPTION
Se desactiva el scroll en caso de estar con el navbar hamburguesa activo  para bloquear que el usuario se mueva en la aplicación con el navbar activado y pueda realizar otras acciones

Antes:



https://github.com/AnaRangel/anarangel.github.io/assets/111030077/ad7ee527-1897-45fe-81a9-20b0ae3dabb5

Despues: 

https://github.com/AnaRangel/anarangel.github.io/assets/111030077/e9ec0719-253c-4b09-be2a-e6ed3d0d2eba

