### PR TITLE
fix: fix scroll padding top

### DIFF
--- a/src/styles/base/_general.scss
+++ b/src/styles/base/_general.scss
@@ -1,6 +1,7 @@
 html {
   scrollbar-gutter: stable;
   scrollbar-width: thin;
+  scroll-padding-top: 4rem;
 }
 
 body {


### PR DESCRIPTION
Se soluciona el error que al navegar hacia los proyectos la card quedaba al nivel del viewport.

Antes:

https://github.com/AnaRangel/anarangel.github.io/assets/38303370/a4c55870-3be9-4f6b-bfbb-126f7434c72a

Después:

https://github.com/AnaRangel/anarangel.github.io/assets/38303370/ad91531a-9f34-4ccd-a3b8-67d8f8475c01