### PR TITLE
fix: fix filter to show easter egg automatically only in 404 paths

### DIFF
--- a/src/components/Avatar.astro
+++ b/src/components/Avatar.astro
@@ -90,12 +90,10 @@
       }, 6000);
     }
 
-    const paths = ['/', '/about-me'];
-
-    if (!paths.includes(window.location.pathname)) {
+    if (document.querySelector('.container-404')) {
       setTimeout(() => {
         activateEasterEgg();
-      }, 5000);
+      }, 3500);
     }
   });
 </script>


### PR DESCRIPTION
Se corrige el filtro que hace que se active automáticamente el easter egg, para que solamente se muestre de esta manera en cualquier ruta que sea 404, y en las páginas principales se active con el atajo de teclado.

https://github.com/AnaRangel/anarangel.github.io/assets/38303370/ce21d452-6d72-40e9-ab22-dc9c620fbd21

