### PR TITLE
fix: fix show designers avatars in brave browser

### DIFF
--- a/astro.config.ts
+++ b/astro.config.ts
@@ -3,6 +3,9 @@ import { defineConfig } from 'astro/config';
 // https://astro.build/config
 export default defineConfig({
   site: 'https://anarangel.github.io',
+  image: {
+    domains: ['media.licdn.com'],
+  },
   vite: {
     build: {
       cssMinify: 'lightningcss',

--- a/src/pages/_Sections/Contributors/Contributors.astro
+++ b/src/pages/_Sections/Contributors/Contributors.astro
@@ -1,4 +1,5 @@
 ---
+import { Picture } from 'astro:assets';
 import designersData from './designers.json';
 
 interface Designer {
@@ -28,10 +29,13 @@ const dataDesigners: Designer[] = designersData;
     {
       dataDesigners.map((designer) => (
         <a href={designer.html_url} target="_blank" class="contributor" title={designer.name}>
-          <img
-            src={designer.avatar_url}
-            alt={`Avatar ${designer.name}`}
+          <Picture
             class="contributors__img"
+            src={designer.avatar_url}
+            formats={['avif', 'webp']}
+            alt={`Avatar ${designer.name}`}
+            width={45}
+            height={45}
           />
         </a>
       ))


### PR DESCRIPTION
Este PR soluciona la issue #132.

El navegador Brave bloqueaba las peticiones al CDN de LinkedIn, por lo que no se podían obtener los avatares de los contribuidores de Diseño. Se utilizó el componente nativo `<Picture>` de Astro para solucionar este error, ya que hace el fetch desde el servidor además de optimizar las imágenes, evitando que el fetch se haga desde el navegador para que las imágenes no sean bloqueadas.

Antes:
![image](https://github.com/AnaRangel/anarangel.github.io/assets/38303370/a3162f9e-93c8-4e7d-9bfc-f95d4b50e494)

Después:
![image](https://github.com/AnaRangel/anarangel.github.io/assets/38303370/ebade254-d353-4c9f-a5ee-4c0a6b99073a)
