### PR TITLE
fix: add infinite horizontal scroll in testimonials

### DIFF
--- a/src/pages/about-me/_Sections/Testimonials/Testimonials.astro
+++ b/src/pages/about-me/_Sections/Testimonials/Testimonials.astro
@@ -14,7 +14,7 @@ import { dataTestimonies } from '@data/testimonies';
     </article>
 
     <div class="testimonials__cards">
-      <div class="testimonials__cards--marquee">
+      <div id="scroller" class="testimonials__cards--marquee">
         {
           dataTestimonies.map((item) => (
             <TestimonyCard
@@ -34,9 +34,11 @@ import { dataTestimonies } from '@data/testimonies';
 
 <style>
   .testimonials {
+    --gap: 48px;
+
     display: flex;
     padding: 72px 36px 72px 36px;
-    gap: 48px;
+    gap: var(--gap);
     opacity: 0px;
     overflow: hidden;
     max-width: 1280px;
@@ -76,40 +78,36 @@ import { dataTestimonies } from '@data/testimonies';
     animation-play-state: paused;
   }
 
-  @keyframes animate-carousel-movil {
-    0% {
-      transform: translateX(58%);
-    }
-    100% {
-      transform: translateX(calc(-100%));
-    }
-  }
-
-  @keyframes animate-carousel-pc {
-    0% {
-      transform: translateX(58%);
-    }
-    100% {
-      transform: translateX(calc(-100%));
-    }
-  }
-
   .testimonials__cards--marquee {
+    --animation-duration: 20s;
+
     width: max-content;
     display: flex;
-    gap: 48px;
-    animation: animate-carousel-pc 40s linear infinite;
+    gap: var(--gap);
+    animation: scroll var(--animation-duration) linear infinite;
   }
 
   @media (max-width: 1000px) {
     .testimonials {
       flex-direction: column;
       align-items: center;
-      gap: 48px;
+      gap: var(--gap);
     }
+  }
 
-    .testimonials__cards--marquee {
-      animation: animate-carousel-movil 50s linear infinite;
+  @keyframes scroll {
+    to {
+      transform: translate(calc(-50% - calc(var(--gap) / 2)));
     }
   }
 </style>
+
+<script>
+  const scroller = document.querySelector('#scroller');
+  const cardTestimony = document.querySelectorAll('.card-testimony');
+
+  cardTestimony.forEach((testimony) => {
+    const duplicateContent = testimony.cloneNode(true);
+    scroller?.appendChild(duplicateContent);
+  });
+</script>

--- a/src/pages/about-me/_Sections/Testimonials/Testimonials.astro
+++ b/src/pages/about-me/_Sections/Testimonials/Testimonials.astro
@@ -79,7 +79,7 @@ import { dataTestimonies } from '@data/testimonies';
   }
 
   .testimonials__cards--marquee {
-    --animation-duration: 20s;
+    --animation-duration: 50s;
 
     width: max-content;
     display: flex;


### PR DESCRIPTION
Este PR resuelve #121.

Se corrigió la funcionalidad de scroll infinito horizontal en la sección de testimonios en la página /about-me.

_Para mostrar el ejemplo la animación tiene una duración de 30 segundos, en el código se ajustó a 50 segundos._

_En móvil funciona de la misma manera._

Antes:

https://github.com/AnaRangel/anarangel.github.io/assets/38303370/ed63f1d2-4bd5-4809-bea4-317024702dab

Después:

https://github.com/AnaRangel/anarangel.github.io/assets/38303370/a50a1dd0-d1f3-47c9-a278-8ae35d6a2566
