### PR TITLE
style: fix images about bank ripley design

### DIFF
--- a/src/pages/banco-ripley/_sections/Designs.astro
+++ b/src/pages/banco-ripley/_sections/Designs.astro
@@ -14,6 +14,7 @@
       </p>
 
       <img
+        class="hide-mobile"
         src="/assets/images/banco-ripley-benchmarks-3.png"
         alt="Pantalla de selección de vuelo de LATAM Airlines con observaciones de UX y comentarios de usuarios"
       />
@@ -73,6 +74,7 @@
   .image-container {
     display: flex;
     flex-direction: column;
+    align-items: center;
     gap: 2rem;
     padding-inline: 2rem;
     margin-block-start: 4rem;
@@ -85,6 +87,14 @@
     max-block-size: 31.25rem;
     margin-inline: auto;
   }
+
+  @media (width <= 768px) {
+    .hide-mobile {
+      display: none;
+      content-visibility: hidden;
+    }
+  }
+
   @media (min-width: 48em) {
     .title {
       font-size: 2rem;
@@ -99,10 +109,6 @@
     }
 
     .image-container img {
-      max-inline-size: unset;
-      max-block-size: unset;
-      block-size: unset;
-      inline-size: unset;
       flex-shrink: 1;
       flex-basis: 15rem;
     }


### PR DESCRIPTION
Se corrigen las imágenes sobre el diseño del Banco Ripley.

Antes:

![image](https://github.com/user-attachments/assets/38dba281-d0f3-49a6-8039-60e216b3c3d1)

Después:

![image](https://github.com/user-attachments/assets/8de062bf-b38c-452d-b5e1-039ffe9f34ed)

En móvil se ocultó la imagen que no tiene muy buena visualización.

Antes:

![image](https://github.com/user-attachments/assets/a7833174-b152-4d73-ae68-028e0ac1d42e)

Después:

![image](https://github.com/user-attachments/assets/47265d54-cf1a-493e-b736-72897af7df14)
