### PR TITLE
style: fix .grid-auto-fit responsive

### DIFF
--- a/src/routes/index.astro
+++ b/src/routes/index.astro
@@ -59,6 +59,16 @@ import { GradientColor } from '../components/GradientBackground/GradientBackgrou
     margin: 0 auto;
   }
 
+  @media (width >= 992px) {
+    .grid-auto-fit {
+      --min-item-width: 30rem;
+      --grid-gap: 2rem;
+
+      margin-inline: auto;
+      max-width: 100%;
+    }
+  }
+
   main {
     overflow: hidden;
   }
@@ -71,14 +81,6 @@ import { GradientColor } from '../components/GradientBackground/GradientBackgrou
         max-width: 1280px;
         margin: 0 auto;
       }
-    }
-
-    .grid-auto-fit {
-      --min-item-width: 30rem;
-      --grid-gap: 2rem;
-
-      margin-inline: auto;
-      max-width: 100%;
     }
   }
 </style>


### PR DESCRIPTION
Este PR soluciona el error de responsive en las cards de Banco Ripley y Cencosud en la web en producción.

Antes:

![image](https://github.com/user-attachments/assets/6a8ce7e5-03f9-482c-89ef-4f6c70fb7903)

Después:

![image](https://github.com/user-attachments/assets/600c0703-c453-4680-9a66-ae436e8a99ca)
