### PR TITLE
refactor: remove CSS nesting selectors due side effect after build

### DIFF
--- a/src/components/Aurora.astro
+++ b/src/components/Aurora.astro
@@ -20,26 +20,26 @@
     filter: blur(70px);
     opacity: 0.3;
     scale: 1.5;
+  }
 
-    &:nth-child(2) {
-      background: #9452ff;
-      translate: var(--translate-child-2);
-      animation: move-2 20s linear infinite;
-    }
+  .aurora:nth-child(2) {
+    background: #9452ff;
+    translate: var(--translate-child-2);
+    animation: move-2 20s linear infinite;
+  }
 
-    &:nth-child(3) {
-      left: 50%;
-      background: #ed8f9e;
-      translate: var(--translate-child-3);
-      animation: move-3 20s linear infinite;
-    }
+  .aurora:nth-child(3) {
+    left: 50%;
+    background: #ed8f9e;
+    translate: var(--translate-child-3);
+    animation: move-3 20s linear infinite;
+  }
 
-    &:nth-child(4) {
-      right: 0;
-      background: #11005f;
-      translate: var(--translate-child-4);
-      animation: move-4 20s linear infinite;
-    }
+  .aurora:nth-child(4) {
+    right: 0;
+    background: #11005f;
+    translate: var(--translate-child-4);
+    animation: move-4 20s linear infinite;
   }
 
   @keyframes move-2 {

--- a/src/components/Buttons/Button.astro
+++ b/src/components/Buttons/Button.astro
@@ -1,5 +1,13 @@
 ---
-import { ButtonSize, ButtonVariant, HtmlType, type ColorVariants, IconCatalog, IconSize, IconStyle } from '@contracts'
+import {
+  ButtonSize,
+  ButtonVariant,
+  HtmlType,
+  IconCatalog,
+  IconSize,
+  IconStyle,
+  type ColorVariants
+} from '@contracts'
 import Icon from '@components/Icon.astro'
 
 interface Props {
@@ -138,10 +146,6 @@ const computedIconSize = iconSizeMap[size]
     z-index: 1;
     inline-size: 90%;
 
-    @media (width >= 48rem) {
-      inline-size: fit-content;
-    }
-
     padding: var(--padding);
     border: none;
     border-radius: 2.25rem;
@@ -157,36 +161,42 @@ const computedIconSize = iconSizeMap[size]
     /* stylelint-disable-next-line plugin/no-low-performance-animation-properties */
     transition: font-weight 500ms var(--ease-spring-3);
     block-size: var(--height);
+  }
 
-    &:has(svg) {
-      display: flex;
-      gap: 0.625rem;
-      align-items: center;
-      justify-content: center;
+  @media (width >= 48rem) {
+    .button {
+      inline-size: fit-content;
     }
+  }
 
-    &:active {
-      --font-weight: 800;
-    }
+  .button:has(svg) {
+    display: flex !important;
+    gap: 0.625rem;
+    align-items: center;
+    justify-content: center;
+  }
 
-    &::before {
-      position: absolute;
+  .button:active {
+    --font-weight: 800;
+  }
 
-      z-index: -1;
+  .button::before {
+    position: absolute;
 
-      background-image: linear-gradient(to right, var(--gradient-primary));
+    z-index: -1;
 
-      transition: transform 0.3s var(--ease-in-out-3);
+    background-image: linear-gradient(to right, var(--gradient-primary));
 
-      content: '';
-      will-change: transform;
-      inset: 0;
-      inline-size: 200%;
-    }
+    transition: transform 0.3s var(--ease-in-out-3);
 
-    &:hover::before {
-      transform: translateX(-50%);
-    }
+    content: '';
+    will-change: transform;
+    inset: 0;
+    inline-size: 200%;
+  }
+
+  .button:hover::before {
+    transform: translateX(-50%);
   }
 
   .button.inverted {
@@ -194,34 +204,34 @@ const computedIconSize = iconSizeMap[size]
     padding-block: 0.9rem;
 
     background: transparent;
+  }
 
-    &::before {
-      position: absolute;
+  .button.inverted::before {
+    position: absolute;
 
-      padding: 0.125rem;
-      border-radius: 3.125rem;
+    padding: 0.125rem;
+    border-radius: 3.125rem;
 
-      background-image: linear-gradient(to right, var(--gradient-primary));
-      background-size: 200% 200%;
+    background-image: linear-gradient(to right, var(--gradient-primary));
+    background-size: 200% 200%;
 
-      /* stylelint-disable-next-line plugin/no-low-performance-animation-properties */
-      transition: background-position 500ms var(--ease-in-out-3);
+    /* stylelint-disable-next-line plugin/no-low-performance-animation-properties */
+    transition: background-position 500ms var(--ease-in-out-3);
 
-      content: '';
+    content: '';
 
-      inline-size: 100%;
-      inset: 0;
-      mask:
-        linear-gradient(hsl(0deg 0% 100%) 0 0) content-box,
-        linear-gradient(hsl(0deg 0% 100%) 0 0);
+    inline-size: 100%;
+    inset: 0;
+    mask:
+      linear-gradient(hsl(0deg 0% 100%) 0 0) content-box,
+      linear-gradient(hsl(0deg 0% 100%) 0 0);
 
-      mask-composite: exclude;
-    }
+    mask-composite: exclude;
+  }
 
-    &:hover::before {
-      background-position: 100% center;
-      transform: translateX(0%);
-    }
+  .button.inverted:hover::before {
+    background-position: 100% center;
+    transform: translateX(0%);
   }
 
   .button[data-variant='primary'] {
@@ -242,15 +252,15 @@ const computedIconSize = iconSizeMap[size]
   .button:disabled {
     cursor: not-allowed;
     opacity: 0.4;
+  }
 
-    &:hover::before {
-      background-position: initial;
-      transform: translateX(0%);
-    }
+  .button:disabled:hover::before {
+    background-position: initial;
+    transform: translateX(0%);
+  }
 
-    &:active {
-      font-weight: var(--font-weight);
-    }
+  .button:disabled:active {
+    font-weight: var(--font-weight);
   }
 
   /* Size styles */
@@ -258,38 +268,38 @@ const computedIconSize = iconSizeMap[size]
     --padding: 0.375rem 1rem;
     --font-size: calc(var(--size-1) + var(--size-2));
     --height: 2rem;
+  }
 
-    &:has(svg) {
-      --padding: 0.375rem 0.75rem;
-    }
+  .button[data-size='xs']:has(svg) {
+    --padding: 0.375rem 0.75rem;
   }
 
   .button[data-size='sm'] {
     --padding: 0.5rem 1.5rem;
     --font-size: var(--size-3);
     --height: 2.2rem;
+  }
 
-    &:has(svg) {
-      --padding: 0.5rem 1.275rem;
-    }
+  .button[data-size='sm']:has(svg) {
+    --padding: 0.5rem 1.275rem;
   }
 
   .button[data-size='base'] {
     --padding: 1.125rem 2.5rem;
     --font-size: var(--size-3);
+  }
 
-    &:has(svg) {
-      --padding: 0.75rem 2rem;
-    }
+  .button[data-size='base']:has(svg) {
+    --padding: 0.75rem 2rem;
   }
 
   .button[data-size='lg'] {
     --padding: 0.75rem 3.75rem;
     --font-size: 1.25rem;
     --height: 3rem;
+  }
 
-    &:has(svg) {
-      --padding: 0.75rem 3rem;
-    }
+  .button[data-size='lg']:has(svg) {
+    --padding: 0.75rem 3rem;
   }
 </style>


### PR DESCRIPTION
Este pull request incluye cambios en los archivos `src/components/Aurora.astro` y `src/components/Buttons/Button.astro`. Los cambios están enfocados en remover los selectores de nesting debido a un efecto secundario que provoca error después de hacer build, y tomaba como selector padre al `:root` en lugar del propio elemento contenedor.