### PR TITLE
refactor: update gradient handling to use new color definitions and simplify props

### DIFF
--- a/src/components/GradientBackground.astro
+++ b/src/components/GradientBackground.astro
@@ -1,5 +1,5 @@
 ---
-import { type GradientsColors, GRADIENTS_COLORS } from "@contracts"
+import { type GradientsColors, COLORS } from "@contracts"
 
 interface Props {
   color: GradientsColors
@@ -7,7 +7,7 @@ interface Props {
 
 const { color } = Astro.props
 
-const gradientColor = GRADIENTS_COLORS[color]
+const gradientColor = COLORS[color]
 ---
 
 <div

--- a/src/components/GradientBackground.astro
+++ b/src/components/GradientBackground.astro
@@ -1,28 +1,18 @@
 ---
-import { type GradientBackgroundProps, GradientColor } from "@contracts"
+import { type GradientsColors, GRADIENTS_COLORS } from "@contracts"
 
-const { color, class: className } = Astro.props as GradientBackgroundProps
-
-const gradients: Record<GradientColor, string> = {
-  [GradientColor.blue]:
-    'radial-gradient(48.42% 48.42% at 49.41% 51.58%, rgba(46, 88, 255, 0.34) 0%, rgba(0, 0, 0, 0.00) 100%)',
-  [GradientColor.purple]:
-    'radial-gradient(48.42% 48.42% at 49.41% 51.58%, rgba(148, 82, 255, 0.40) 0%, rgba(0, 0, 0, 0.00) 100%)',
-  [GradientColor.darkPurple]:
-    'radial-gradient(48.42% 48.42% at 49.41% 51.58%, #1E0D4F 0%, rgba(0, 0, 0, 0.00) 100%)',
-  [GradientColor.darkBlue]:
-    'radial-gradient(48.42% 48.42% at 49.41% 51.58%, #061962 0%, rgba(0, 0, 0, 0.00) 100%)',
-  [GradientColor.cyan]:
-    'radial-gradient(35.82% 35.18% at 50.01% 50%, rgba(48, 183, 202, 0.30) 0%, rgba(33, 212, 155, 0.00) 100%)'
+interface Props {
+  color: GradientsColors
 }
 
-const gradientStyle = gradients[color]
-const Class = className ? ` ${className}` : ''
+const { color } = Astro.props
+
+const gradientColor = GRADIENTS_COLORS[color]
 ---
 
 <div
-  class={`gradient-background${Class}`}
-  style={`--gradient: ${gradientStyle}`}
+  class="gradient-background"
+  style={`--gradient: ${gradientColor}`}
 >
   <slot />
 </div>

--- a/src/contracts/gradients.type.ts
+++ b/src/contracts/gradients.type.ts
@@ -11,6 +11,6 @@ export type GradientsColors = keyof typeof colorValues;
 
 const BASE_GRADIENT = 'radial-gradient(48.42% 48.42% at 49.41% 51.58%, COLOR_PLACEHOLDER 0%, transparent 100%)';
 
-export const GRADIENTS_COLORS = Object.fromEntries(
+export const COLORS = Object.fromEntries(
   Object.entries(colorValues).map(([name, gradient]) => [name, BASE_GRADIENT.replace('COLOR_PLACEHOLDER', gradient)])
 ) as Record<GradientsColors, string>;

--- a/src/contracts/gradients.type.ts
+++ b/src/contracts/gradients.type.ts
@@ -1,12 +1,16 @@
-export enum GradientColor {
-  blue = 'blue',
-  purple = 'purple',
-  darkPurple = 'darkPurple',
-  darkBlue = 'darkBlue',
-  cyan = 'cyan'
-}
+const colorValues = {
+  blue: 'rgba(46, 88, 255, 0.34)',
+  purple: 'rgba(148, 82, 255, 0.40)',
+  darkPurple: '#1E0D4F',
+  darkBlue: '#061962',
+  cyan: 'rgba(48, 183, 202, 0.30)',
+  pink: 'rgba(248, 128, 214, 0.34)'
+};
 
-export interface GradientBackgroundProps {
-  color: GradientColor
-  class?: string
-}
+export type GradientsColors = keyof typeof colorValues;
+
+const BASE_GRADIENT = 'radial-gradient(48.42% 48.42% at 49.41% 51.58%, COLOR_PLACEHOLDER 0%, transparent 100%)';
+
+export const GRADIENTS_COLORS = Object.fromEntries(
+  Object.entries(colorValues).map(([name, gradient]) => [name, BASE_GRADIENT.replace('COLOR_PLACEHOLDER', gradient)])
+) as Record<GradientsColors, string>;

--- a/src/routes/banco-ripley.astro
+++ b/src/routes/banco-ripley.astro
@@ -1,5 +1,4 @@
 ---
-import { GradientColor } from '@contracts'
 import GradientBackground from '@components/GradientBackground.astro'
 import Layout from '@layouts/Layout.astro'
 import Contact from '@sections/sections/Contact.astro'
@@ -13,7 +12,7 @@ import Hero from '@sections/banco-ripley/Hero.astro'
 
 <Layout title="Ana Rangel | Banco Ripley">
   <main>
-    <GradientBackground color={GradientColor.blue} />
+    <GradientBackground color="blue" />
 
     <Hero />
     <Context />

--- a/src/routes/index.astro
+++ b/src/routes/index.astro
@@ -1,5 +1,5 @@
 ---
-import { CardVariant, GradientColor } from '@contracts'
+import { CardVariant } from '@contracts'
 import AnaCards from '@sections/home/AnaCards.astro'
 import Contributors from '@sections/home/Contributors.astro'
 import Hero from '@sections/home/Hero.astro'
@@ -46,7 +46,7 @@ import { t } from 'i18n:astro'
   />
 
   <main>
-    <GradientBackground color={GradientColor.blue} />
+    <GradientBackground color="blue" />
     <Hero />
     <div class="container">
       <Profession />

--- a/src/routes/latam-airlines.astro
+++ b/src/routes/latam-airlines.astro
@@ -1,5 +1,4 @@
 ---
-import { GradientColor } from '@contracts'
 import GradientBackground from '@components/GradientBackground.astro'
 import Layout from '@layouts/Layout.astro'
 import Contact from '@sections/sections/Contact.astro'
@@ -12,7 +11,7 @@ import Process from '@sections/latam-airlines/Process.astro'
 
 <Layout title="Ana Rangel | Latam Airlines">
   <main>
-    <GradientBackground color={GradientColor.blue} />
+    <GradientBackground color="blue" />
 
     <Hero />
     <Context />

--- a/src/routes/sobre-mi.astro
+++ b/src/routes/sobre-mi.astro
@@ -1,5 +1,4 @@
 ---
-import { GradientColor } from '@contracts'
 import GradientBackground from '@components/GradientBackground.astro'
 import Layout from '@layouts/Layout.astro'
 import Contact from '@sections/sections/Contact.astro'
@@ -11,7 +10,7 @@ import Tools from '@sections/about/tools/Tools.astro'
 
 <Layout title="Sobre mí • Ana Rangel">
   <main>
-    <GradientBackground color={GradientColor.purple} />
+    <GradientBackground color="purple" />
     <BasicInfo />
     <Tools />
     <Hobbies />


### PR DESCRIPTION
Este pull request incluye la refactorización de la gestión de los colores de degradado, la eliminación del enum `GradientColor` y actualizaciones del uso de los colores de degradado en los archivos donde se instancia el componente.

### Refactorización:

* [`src/components/GradientBackground.astro`](diffhunk://#diff-4fe260ce71ec6f91fc27830843e95661546a631821aa0470b22f498a4fcffc8aL2-R15): Refactorizado para usar `GradientsColors` y `GRADIENTS_COLORS` en lugar del enum `GradientColor` simplificando la aplicación del estilo de degradado.
* [`src/contracts/gradients.type.ts`](diffhunk://#diff-09d281a0ee30f4c12745f71ab6678823334d4b878475e1e2cf21015eb95ac38bL1-R16): Eliminado el enum `GradientColor` y la interfaz `GradientBackgroundProps`. Añadidas las constantes `colorValues` y `BASE_GRADIENT`, y creado `GRADIENTS_COLORS` para asignar nombres de colores a estilos de degradado.

### Actualizaciones en el uso de colores degradados:

* [`src/routes/banco-ripley.astro`](diffhunk://#diff-cc930d48629809601926463ea0eae4a45b64798a610963f51a8e133a054543f6L2): Se ha eliminado la importación de `GradientColor` y se ha actualizado el uso del valor del color. [[1]](diffhunk://#diff-cc930d48629809601926463ea0eae4a45b64798a610963f51a8e133a054543f6L2) [[2]](diffhunk://#diff-cc930d48629809601926463ea0eae4a45b64798a610963f51a8e133a054543f6L16-R15)

* [`src/routes/index.astro`](diffhunk://#diff-a6c00bf15ae99818a9d9ad407a92b772d12ac67f019cf0570becff0626f58a26L2-R2): Se ha eliminado la importación de `GradientColor` y se ha actualizado el uso del valor del color. [[1]](diffhunk://#diff-a6c00bf15ae99818a9d9ad407a92b772d12ac67f019cf0570becff0626f58a26L2-R2) [[2]](diffhunk://#diff-a6c00bf15ae99818a9d9ad407a92b772d12ac67f019cf0570becff0626f58a26L49-R49)

* [`src/routes/latam-airlines.astro`](diffhunk://#diff-7c0ea520dc2ed1a1dc937b12fcb495a1ebd46dfcb018c0cb441e2c23066708e4L2): Se ha eliminado la importación de `GradientColor` y se ha actualizado el uso del valor del color. [[1]](diffhunk://#diff-7c0ea520dc2ed1a1dc937b12fcb495a1ebd46dfcb018c0cb441e2c23066708e4L2) [[2]](diffhunk://#diff-7c0ea520dc2ed1a1dc937b12fcb495a1ebd46dfcb018c0cb441e2c23066708e4L15-R14)

* [`src/routes/sobre-mi.astro`](diffhunk://#diff-718b9bbf36a556b788974e26d7b0f43af80505c34f8339aabd80ef52441c4217L2): Se ha eliminado la importación de `GradientColor` y se ha actualizado el uso del valor del color. [[1]](diffhunk://#diff-718b9bbf36a556b788974e26d7b0f43af80505c34f8339aabd80ef52441c4217L2) [[2]](diffhunk://#diff-718b9bbf36a556b788974e26d7b0f43af80505c34f8339aabd80ef52441c4217L14-R13)

### Ventajas

Este cambio mejora la DX evitando tener que importar los typos en la instancia del componente `GradientBackground.astro` simplicando su uso, proveyendo autocompletado solamente de los colores declarados directamente en la prop `color`.

https://github.com/user-attachments/assets/fc45e4d9-0061-404d-8407-72557913f7a2
