### PR TITLE
feat: add astro-capo dependency and update layout to use Head component

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "@neodrag/vanilla": "2.3.0",
     "@playform/compress": "0.1.6",
     "astro": "4.4.11",
+    "astro-capo": "0.0.1",
     "embla-carousel": "8.5.2",
     "embla-carousel-autoplay": "8.5.2",
     "i18next": "23.0.0",

--- a/src/layouts/Base.astro
+++ b/src/layouts/Base.astro
@@ -1,4 +1,5 @@
 ---
+import { Head } from 'astro-capo'
 import Avatar from '@components/Avatar.astro'
 import PostHog from '@components/PostHog.astro'
 
@@ -21,7 +22,7 @@ const ogImage = new URL('/img/og.jpg', baseUrl)
 ---
 
 <!doctype html>
-<head>
+<Head>
   <title>{title}</title>
 
   <meta charset="UTF-8" />
@@ -48,7 +49,7 @@ const ogImage = new URL('/img/og.jpg', baseUrl)
   <meta name="robots" content="index, follow" />
 
   <PostHog />
-</head>
+</Head>
 <body>
   <slot />
   <Avatar />


### PR DESCRIPTION
Este pull request añade una nueva dependencia `astro-capo` y la integración del componente `Head` en el archivo `Base.astro`.

## Instalación de la dependencia:

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R46): Añadido el paquete `astro-capo` versión 0.0.1.

## Actualizaciones del layout Base:

* [`src/layouts/Base.astro`](diffhunk://#diff-7f2bb650ebd4f62eed5e3c6f8b11553b541064b5a9ef01c815cb148e716090beR2): Importado el componente `Head` de `astro-capo`.
* [`src/layouts/Base.astro`](diffhunk://#diff-7f2bb650ebd4f62eed5e3c6f8b11553b541064b5a9ef01c815cb148e716090beL24-R25): Se ha sustituido el elemento `<head>` por el componente `<Head>` para gestionar la sección head del documento. [[1]](diffhunk://#diff-7f2bb650ebd4f62eed5e3c6f8b11553b541064b5a9ef01c815cb148e716090beL24-R25) [[2]](diffhunk://#diff-7f2bb650ebd4f62eed5e3c6f8b11553b541064b5a9ef01c815cb148e716090beL51-R52)

## Ventajas de usar `astro-capo`

Esta integración usa por debajo [`capo.js`](https://github.com/rviscomi/capo.js), que utiliza una metodología de ordenar las etiquetas dentro del elemento `<head>` para mejor rendimiento y mejorar el SEO. Orden que utiliza:

![image](https://github.com/user-attachments/assets/c5594ef4-c059-42fc-8d85-ae0bbd31eea2)
